### PR TITLE
Check developer convar before printing invalid ent blip removal

### DIFF
--- a/lua/gminimap/client/blips.lua
+++ b/lua/gminimap/client/blips.lua
@@ -133,6 +133,7 @@ local URLTexturedRectRotated = SDrawUtils.URLTexturedRectRotated
 local Rad, Sin, Cos, Abs = math.rad, math.sin, math.cos, math.abs
 
 local matArrow = Material( "gminimap/heading.png", "smooth ignorez" )
+local cvarDev = GetConVar( "developer" )
 local colorBlack = Color( 0, 0, 0, 255 )
 
 function GMinimap:DrawBlips( radar )
@@ -187,7 +188,10 @@ function GMinimap:DrawBlips( radar )
                 b.position = b.parent:GetPos()
                 b.angle = GetHeading( b.parent )
             else
-                self.Print( "Blip #%d no longer has a valid parent, removing...", i )
+                if cvarDev:GetBool() then
+                    self.Print( "Blip #%d no longer has a valid parent, removing...", i )
+                end
+
                 table.remove( self.blips, i )
             end
         end


### PR DESCRIPTION
In situations where there are a lot of intentional entity removals, this print can easily clutter up the developer console

As a remedy, I have added a check for the default "developer" ConVar, making it so the message is only printed if this ConVar is set to true